### PR TITLE
Updated rule 23: also allow the use of YAML for OAS representations.

### DIFF
--- a/source/api-design-rules/rule_023.md
+++ b/source/api-design-rules/rule_023.md
@@ -2,7 +2,7 @@
 
 | Title    | __23 - API specification__ |
 | :----    | :---------- |
-| Strategy | APIs are to be specified as [OAS v3](https://spec.openapis.org/#openapi-specification), and rendered in either JSON or YAML. |
+| Strategy | APIs are to be specified as [OAS v3](https://spec.openapis.org/#openapi-specification) and rendered in either JSON or YAML. |
 
 
 <details><summary>
@@ -13,7 +13,7 @@ Open section for explanation, rationale and exception conditions
 
 #### Explanation
 
-APIs are to be specified as OpenAPI Specification v3 or higher (OAS3). Details to be found at the [OpenAPI initiative](https://www.openapis.org/) and [https://spec.openapis.org/#openapi-specification] for all specification versions.  This is conform ASNO API-16 [\[2\]](../references.html).
+APIs are to be specified as OpenAPI Specification v3.0 or higher (OAS3). Details to be found at the [OpenAPI initiative](https://www.openapis.org/) and [https://spec.openapis.org/#openapi-specification] for all specification versions.  This is conform ASNO API-16 [\[2\]](../references.html).
 
 The representation format of an OpenAPI specification can be either JSON or YAML, depending on preference. Preferred format is JSON, in compliance with ASNO API-51 [\[2\]](../references.html).
 

--- a/source/api-design-rules/rule_023.md
+++ b/source/api-design-rules/rule_023.md
@@ -2,7 +2,7 @@
 
 | Title    | __23 - API specification__ |
 | :----    | :---------- |
-| Strategy | APIs are to be specified as [OAS v3](https://spec.openapis.org/#openapi-specification), using JSON. |
+| Strategy | APIs are to be specified as [OAS v3](https://spec.openapis.org/#openapi-specification), and rendered in either JSON or YAML. |
 
 
 <details><summary>
@@ -13,13 +13,13 @@ Open section for explanation, rationale and exception conditions
 
 #### Explanation
 
-APIs are to be specified as OpenAPI Specification v3 or higher. Details to be found at the [OpenAPI initiative](https://www.openapis.org/) and [https://spec.openapis.org/#openapi-specification] for all specification versions. 
- 
-We use the JSON format, as we do not support the YAML format. This is conform ASNO API-16 [\[2\]](../references.html).
+APIs are to be specified as OpenAPI Specification v3 or higher (OAS3). Details to be found at the [OpenAPI initiative](https://www.openapis.org/) and [https://spec.openapis.org/#openapi-specification] for all specification versions.  This is conform ASNO API-16 [\[2\]](../references.html).
+
+The representation format of an OpenAPI specification can be either JSON or YAML, depending on preference. Preferred format is JSON, in compliance with ASNO API-51 [\[2\]](../references.html).
 
 #### Rationale
 
-By agreeing on a single specification format (JSON) in accordance with the OAS standard, coordination and collaboration between providers and consumers is simplified and improved. The process that providers publish APIs in JSON format in accordance with OAS3 leads to predictability, improved interoperability and contributes to a higher developer experience for consumers.
+The process that providers publish APIs in accordance with OAS3 leads to predictability, improved interoperability and contributes to a higher developer experience for consumers. The OAS3 standard allows for a representation in either JSON or YAML and ample tools exist to transform from one representation to the other. In compliance with ASNO, there should be at least a JSON version of the OAS3 at a standard location. However, a YAML representation is also allowed.  
 
 #### Exceptions
 


### PR DESCRIPTION
The OAS specification allows either a JSON or YAML representation of the specification and there are many tools to translate between both representations. Since the YAML representation is more user friendly, the proposal is to allow both variants to be used as preferred by the API creator (with a preference for JSON in case the specification must be available for auto-detection).