### PR TITLE
Document generic error codes to resolve issue #91

### DIFF
--- a/docs/attachments/Use-of-HTTP-operations-for-RESTful-APIs.md
+++ b/docs/attachments/Use-of-HTTP-operations-for-RESTful-APIs.md
@@ -17,7 +17,32 @@ Additionally, each operation **should** generate these common error codes:
 - **403 – Forbidden**: The requester has no rights to perform the given operation or may not execute it on the specified resource.
 - **422 – Unprocessable Content**: The request is syntactically correct but the payload contains semantic errors and/or conflicts preventing execution (only applicable for those operations that receive payloads).
 - **500 – Internal Server Error**: The called application encounters a problem that makes it impossible to execute the requested operation.
-- **503 – Service Unavailable**: The called application is currently unavailable.
+
+### Conflict handling
+
+Operations that perform state updates on resources **could** be designed such that the client must explicitly specify a resource state precondition. In that case, each update operation **must** include a precondition header such as [`If-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-Match) or [`If-Unmodified-Since`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-Unmodified-Since) and the server **must** respond with a 428 error code in case the client omits this header (whether or not a conflict actually exists). When the server requires a precondition header to be present, the 428 error code **should** be documented in the OAS specification.
+
+When a conflict actually occurs, the server **should** respond with a 412 error code, indicating that the current state of the resource does not match the provided precondition. In this case, the client **should** perform a GET operation to refresh it's state before attempting another update.
+
+Note that the OAS specification **should** document the 412 error code in case the server is able to provide this code. When the server supports the 428 error code, the 412 code **must** also be specified.
+
+#### 412 - Precondition failed
+
+The precondition given in one or more of the request-header fields evaluated to false when it was tested on the server. This response code allows the client to place preconditions on the current resource metainformation (header field data) and thus prevent the requested method from being applied to a resource other than the one intended. 
+
+The 412 error code can be generated in case any of the preconditions mentioned in the table below are passed to the appropriate HTTP operation (the table only defines those preconditions that might result in a 412 error):
+
+| Header parameter:     | Description:                                                 |
+| --------------------- | ------------------------------------------------------------ |
+| `If-Match`            | The `If-Match` request-header is used with a method to make it conditional. A client that has one or more entities previously obtained from the resource can verify that one of those entities is current by including a list of their associated entity tags (`ETags`) in the `If-Match` header field. As a special case, the value `*` matches any current entity on the resource. <br />If none of the entity tags match, or if `*` is given and no current entity exists, the server **must not** perform the requested method, and **must** return a 412 (Precondition Failed) response. This behavior is most useful when the client wants to prevent an updating method, such as PUT, from modifying a resource that has changed since the client last retrieved it. |
+| `If-None-Match`       | The If-None-Match request-header field is used with a method to make it conditional. A client that has one or more entities previously obtained from the resource can verify that none of those entities is current by including a list of their associated entity tags in the `If-None-Match` header field. The purpose of this feature is to allow efficient updates of cached information with a minimum amount of transaction overhead. It is also used to prevent a method (e.g. PUT) from inadvertently modifying an existing resource when the client believes that the resource does not exist. As a special case, the value `*` matches any current entity on the resource.<br />If any of the entity tags match the entity tag of the entity that would have been returned in the response to a similar GET request (without the `If-None-Match` header) on that resource, or if `*` is given and any current entity exists for that resource, then the server **must not** perform the requested method, unless required to do so because the resource's modification date fails to match that supplied in an `If-Modified-Since` header field in the request.    Instead, if the request method was GET or HEAD, the server **should** respond with a 304 (Not Modified) response, including the cache-related header fields (particularly `ETag`) of one of the entities that matched. For all other request methods, the server **must** respond with a status of 412 (Precondition Failed). |
+| `If-Unmodified-Since` | The `If-Unmodified-Since` request-header field is used with a method to make it conditional. If the requested resource has not been modified since the time specified in this field, the server **should** perform the requested operation as if the **If-Unmodified-Since** header were not present. If the requested variant has been modified since the specified time, the server **must not** perform the requested operation, and **must** return a 412 (Precondition Failed). |
+
+#### 428 - Precondition required
+
+A 428 (Precondition required) error code indicates that the server requires the request to be conditional. Typically, a 428 response means that a required precondition header such as [`If-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-Match) is missing. When a precondition header is present but its value does not match the server-side state, the response **should** be a 412 (Pecondition failed) error code instead.
+
+The 428 code is typical use is to avoid the *lost update* problem, where a client GETs a resource's state, modifies it, and PUTs it back to the server when meanwhile a third party has modified the state on the server, leading to a conflict.  By requiring requests to be conditional, the server can assure that clients are working with the correct copies.
 
 ### Responses to Operations
 
@@ -26,11 +51,11 @@ When designing RESTful APIs, two general approaches can be observed for implemen
 1. Mutation operations (POST, PUT, PATCH) return the (new) state of the modified/created resource.
 2. Mutation operations (POST, PUT, PATCH) return only a status.
 
-Both approaches are allowed from a REST ‘best practices’ perspective. However, the downside of option (1) is that it introduces multiple ‘backdoors’ for retrieving a resource. Particularly in large, complex data structures and/or intricate authorisation models, it is not always straightforward to determine exactly what should be returned. Ideally, these algorithms should be implemented in a single location.
+Both approaches are allowed from a REST ‘best practices’ perspective. However, the downside of option (1) is that it introduces multiple ‘backdoors’ for retrieving a resource. Particularly in large, complex data structures and/or intricate authorisation models, it is not always straightforward to determine exactly what should be returned. Ideally, these algorithms **should** be implemented in a single location.
 
 Additionally, in the case of POST and PUT, the requester already provides most of the resource state in the request, making the response largely redundant. This results in unnecessary overhead, especially in complex data models. Finally, the response from POST, PUT, and PATCH is not inherently cacheable, unlike GET.
 
-Considering the above, only option (2) is permitted: POST, PUT, and PATCH must return *only a status*, and the GET operation **should** be used to retrieve the resource state. In some cases (where the requester immediately requires the new state), this results in the overhead of one additional GET call. However, the advantages outweigh this drawback.
+Considering the above, only option (2) is permitted: POST, PUT, and PATCH **must** return *only a status*, and the GET operation **should** be used to retrieve the resource state. In some cases (where the requester immediately requires the new state), this results in the overhead of one additional GET call. However, the advantages outweigh this drawback.
 
 ------
 
@@ -88,7 +113,8 @@ The operation **may** result in the following response codes:
 - **204 – No Content**: The replacement was successful, and no response is returned, as the updated resource state can be retrieved via a GET request (see justification under GET). The response **may** optionally include an **ETag** header containing the (new) ETag key of the modified resource.
 - **404 – Not Found**: The provided ID does not correspond to a valid resource.
 - **409 – Conflict**: The resource exists, but its current state prevents updates, for example, because it is locked or because a required (parent) resource is missing.
-- **412 - Precondition Failed**: The provided **ETag** value does not match the current state of the resource (stale state).
+- **412 - Precondition Failed**: The provided precondition (either `ETag` or last-modified timestamp) does not match the current state of the resource (stale state).
+- **428 - Precondition Required**: The server requires a precondition header (such as `If-Match` or `If-Unmodified-Since`) to be present and the client failed to provide them.
 
 A PUT request must never contain a response body (except for responses related to error messages)!
 
@@ -203,6 +229,7 @@ The operation **may** result in the following response codes:
 - **204 – No Content**: The resource(s) have been successfully deleted.
 - **409 – Conflict**: The operation cannot be executed because the current state does not allow it (e.g. because the collection or resource is locked or child resources have to be deleted first).
 - **412 - Precondition Failed**: The provided **ETag** value does not match the current state of the resource (stale state).
+- **428 - Precondition Required**: The server requires a precondition header (such as `If-Match` or `If-Unmodified-Since`) to be present and the client failed to provide them.
 
 ### Justification
 
@@ -251,6 +278,7 @@ The operation **may** result in the following response codes:
 - **404 – Not Found**: The specified ID does not correspond to a valid resource.
 - **409 – Conflict**: The resource exists, but its current state makes it impossible to update, e.g., because it is locked.
 - **412 - Precondition Failed**: The provided **ETag** value does not match the current state of the resource (stale state).
+- **428 - Precondition Required**: The server requires a precondition header (such as `If-Match` or `If-Unmodified-Since`) to be present and the client failed to provide them.
 
 A PATCH operation **should not** contain a response body (except for error messages that are part of failure responses)!
 

--- a/docs/attachments/Use-of-HTTP-operations-for-RESTful-APIs.md
+++ b/docs/attachments/Use-of-HTTP-operations-for-RESTful-APIs.md
@@ -14,9 +14,11 @@ Additionally, each operation **should** generate these common error codes:
 
 - **400 – Bad Request**: The request contains syntactic errors that make execution impossible. This also pertains to all types of errors in query- and/or header parameters.
 - **401 – Unauthorized**: The requester must authenticate before calling the operation.
-- **403 – Forbidden**: The requester has no rights to perform the given operation or may not execute it on the specified resource.
+- **403 – Forbidden**: The server understands the request (and knows the identity of the client), but otherwise refuses to process the request due to application logic, such as insufficient permissions to a resource or action.
 - **422 – Unprocessable Content**: The request is syntactically correct but the payload contains semantic errors and/or conflicts preventing execution (only applicable for those operations that receive payloads).
 - **500 – Internal Server Error**: The called application encounters a problem that makes it impossible to execute the requested operation.
+
+In order not to disclose the existence of specific resource entities that the client has no access to, operations **should** return a **404** error (Not Found) instead of a **403** (Forbidden) for these specific situations.
 
 ### Conflict handling
 

--- a/docs/attachments/errorhandling.md
+++ b/docs/attachments/errorhandling.md
@@ -21,7 +21,7 @@ A 405 (Method not allowed) error code indicates that the server knows the reques
 
 ### 429 - Too many requests
 
-A 429 (Too many requests) error code is typically issued when the client sends more requests per unit of time that the server is willing or able to process. The error code **should** be accompanied by a HTTP [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) header which specifies the time (in seconds) that the client should wait until attempting new requests. Depending on the API gateway, other HTTP headers **may** be supplied as well, providing additional information.
+A 429 (Too many requests) error code is typically issued when the client sends more requests per unit of time than the server is willing or able to process. The error code **should** be accompanied by a HTTP [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) header which specifies the time (in seconds) that the client should wait until attempting new requests. Depending on the API gateway, other HTTP headers **may** be supplied as well, providing additional information.
 
 ### 501 - Not implemented
 

--- a/docs/attachments/errorhandling.md
+++ b/docs/attachments/errorhandling.md
@@ -19,10 +19,6 @@ The scope of standardized error reporting is **only** the application that imple
 
 A 405 (Method not allowed) error code indicates that the server knows the request method, but the target resource does not currently support this method. The server **must** generate an [`Allow`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Allow) header in a 405 response with a list of methods that the target resource currently supports.
 
-### 428 - Precondition required
-
-A 428 (Precondition required) error code indicates that the server requires the request to be conditional. Typically, a 428 response means that a required precondition header such as [`If-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-Match) is missing. When a precondition header does not match the server-side state, the response **should** be a 412 (Pecondition failed) error code instead.
-
 ### 429 - Too many requests
 
 A 429 (Too many requests) error code is typically issued when the client sends more requests per unit of time that the server is willing or able to process. The error code **should** be accompanied by a HTTP [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) header which specifies the time (in seconds) that the client should wait until attempting new requests. Depending on the API gateway, other HTTP headers **may** be supplied as well, providing additional information.

--- a/docs/attachments/errorhandling.md
+++ b/docs/attachments/errorhandling.md
@@ -13,7 +13,7 @@ HTTP error codes typically have two sources:
 1. The *application* that implements the invoked RESTful API (*explicit* error codes);
 2. The *network components* that exist between the client and the application (*implicit* error codes);
 
-The scope of standardized error reporting is **only** the application that implements the RESTful API (*implicit* codes). Client applications **must** be aware that the second category exists and that they can thus receive HTTP errors from network components that are not explicitly documented in the *Open API Specification* (OAS) schemas. Examples of common implicit codes are 405 (Method not allowed), 428 (Precondition required), 429 (Too many requests), 501 (Not implemented) or 503 (Service unavailable). The format of the response for an implicit error code is **undefined** since it depends on the network component that issued the error. Clients **should** be designed such that they can properly process **any** explicit or implicit HTTP error code.
+The scope of standardized error reporting is **only** the application that implements the RESTful API (*explicit* codes). Client applications **must** be aware that the second category exists and that they can thus receive HTTP errors from network components that are not documented in the *Open API Specification* (OAS) schemas (implicit error codes **could** be documented but this is not mandatory). Examples of common implicit codes are 405 (Method not allowed), 428 (Precondition required), 429 (Too many requests), 501 (Not implemented) or 503 (Service unavailable). The format of the response for an implicit error code is **undefined** since it depends on the network component that issued the error. Clients **should** be designed such that they can properly process **any** explicit or implicit HTTP error code.
 
 ### 405 - Method not allowed
 
@@ -29,7 +29,7 @@ A 429 (Too many requests) error code is typically issued when the client sends m
 
 ### 501 - Not implemented
 
-A 501 (Not implemented) error code means that the server does not support the functionality required to fulfill the request. A response with this status **may** also include a [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) header, telling the client that they can retry the request after the specified time has elapsed.
+A 501 (Not implemented) error code means that the server does not support the functionality required to fulfill the request.
 
 A 501 code is the appropriate response when the server does not recognize the request method and is incapable of supporting it for any resource. Servers are required to support [`GET`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/GET) and [`HEAD`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/HEAD), and therefore **must not** return `501` in response to requests with these methods. If the server does recognize the method, but intentionally does not allow it, the appropriate response is a 405 (Method not allowed) error code.
 

--- a/docs/attachments/errorhandling.md
+++ b/docs/attachments/errorhandling.md
@@ -6,13 +6,48 @@ When designing RESTful APIs, it is essential to pay sufficient attention to appl
 
 The objective of this chapter is to introduce a standardized approach to error reporting.
 
+## Implicit error codes
+
+HTTP error codes typically have two sources:
+
+1. The *application* that implements the invoked RESTful API (*explicit* error codes);
+2. The *network components* that exist between the client and the application (*implicit* error codes);
+
+The scope of standardized error reporting is **only** the application that implements the RESTful API (*implicit* codes). Client applications **must** be aware that the second category exists and that they can thus receive HTTP errors from network components that are not explicitly documented in the *Open API Specification* (OAS) schemas. Examples of common implicit codes are 405 (Method not allowed), 428 (Precondition required), 429 (Too many requests), 501 (Not implemented) or 503 (Service unavailable). The format of the response for an implicit error code is **undefined** since it depends on the network component that issued the error. Clients **should** be designed such that they can properly process **any** explicit or implicit HTTP error code.
+
+### 405 - Method not allowed
+
+A 405 (Method not allowed) error code indicates that the server knows the request method, but the target resource does not currently support this method. The server **must** generate an [`Allow`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Allow) header in a 405 response with a list of methods that the target resource currently supports.
+
+### 428 - Precondition required
+
+A 428 (Precondition required) error code indicates that the server requires the request to be conditional. Typically, a 428 response means that a required precondition header such as [`If-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-Match) is missing. When a precondition header does not match the server-side state, the response **should** be a 412 (Pecondition failed) error code instead.
+
+### 429 - Too many requests
+
+A 429 (Too many requests) error code is typically issued when the client sends more requests per unit of time that the server is willing or able to process. The error code **should** be accompanied by a HTTP [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) header which specifies the time (in seconds) that the client should wait until attempting new requests. Depending on the API gateway, other HTTP headers **may** be supplied as well, providing additional information.
+
+### 501 - Not implemented
+
+A 501 (Not implemented) error code means that the server does not support the functionality required to fulfill the request. A response with this status **may** also include a [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) header, telling the client that they can retry the request after the specified time has elapsed.
+
+A 501 code is the appropriate response when the server does not recognize the request method and is incapable of supporting it for any resource. Servers are required to support [`GET`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/GET) and [`HEAD`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/HEAD), and therefore **must not** return `501` in response to requests with these methods. If the server does recognize the method, but intentionally does not allow it, the appropriate response is a 405 (Method not allowed) error code.
+
+### 503 - Service unavailable
+
+A 503 (Service unvailable) error code indicates that the server is currently not ready to handle the request. Common causes are that a server is down for maintenance or overloaded. During maintenance, servers **may** return a 503 error for the duration of the maintenance session. In overload cases, some server-side applications will reject requests with a 503 error when resource thresholds like memory, CPU, or connection pool limits are met. Dropping incoming requests creates backpressure that prevents the server's compute resources from being exhausted, avoiding more severe failures. 
+
+If requests from specific clients are being restricted due to rate limiting, the server **should** return a 429 (Too many requests) error code instead of a 503.
+
+The 503 error response **should** be used for *temporary conditions* and the [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) HTTP header **should** contain the estimated time for the recovery of the service, if possible.
+
 ------
 
-## A Standard: RFC-9457
+## An error reporting standard: RFC-9457
 
 The [Dutch government API strategy](https://docs.geostandaarden.nl/api/API-Strategie-ext/#error-handling-0) designates the [RFC-7807](https://datatracker.ietf.org/doc/html/rfc7807) standard as the basis for error reporting. However, this RFC has since been replaced by [RFC-9457](https://datatracker.ietf.org/doc/html/rfc9457), and the recommendation to the sector is to follow this latest version. The differences between the two are minimal.
 
-The content type to be used for error responses according to RFC-9457 is:
+The content type to be used for error responses according to RFC-9457 **must** be:
 
 `application/problem+json`
 
@@ -20,7 +55,7 @@ The RFC-9457 standard defines a ‘*Problem Details Record*,’ which **should**
 
 | Atttribute: | Definition:                                                  |
 | ----------- | ------------------------------------------------------------ |
-| *type*      | A JSON string in the form of a URI reference that uniquely identifies the type of error. Different error types must have distinct URIs. If the URI is structured as a URL (i.e., starting with ‘http’ or ‘https’), it should ideally be dereferenceable, leading to a page with detailed information about the error type.<br />The type attribute may have the value "about:blank" if the HTTP status code itself is deemed sufficiently clear to serve as a response. However, this will rarely be the case.<br />Examples of type values include "*Validation*", "*StateConflict*", or "*Access*".<br />See here for a proposal on structuring type fields. |
+| *type*      | A JSON string in the form of a URI reference that uniquely identifies the type of error. Different error types must have distinct URIs. If the URI is structured as a URL (i.e., starting with ‘http’ or ‘https’), it should ideally be dereferenceable, leading to a page with detailed information about the error type.<br />The type attribute may have the value "about:blank" if the HTTP status code itself is deemed sufficiently clear to serve as a response. However, this will rarely be the case.<br /><br />Since the URI standard dictates that standardized URI's should be used for standardized terms and definitions, the URI '`https://datatracker.ietf.org/doc/html/rfc9110#name-{code}-{code-summary}`' **should** be used. |
 | *title*     | A short JSON string providing a human-readable description of the error **type**, such as "*Unable to authenticate client*" or "*Parameter validation errors*".<br/>The type and title fields are intrinsically linked, where **type** identifies the *error category*, and **title** provides a *comprehensible name* for it.<br/>If type has the value `about:blank`, the title field is expected to contain the normative name of the associated HTTP status code (e.g., "*Forbidden*" for HTTP 403). |
 | *status*    | A JSON number corresponding to the original HTTP status code generated by the server for the error. This code may differ from the actual HTTP response code due to modifications by routers, gateways, firewalls, or other intermediaries between the client and the server. |
 
@@ -34,9 +69,9 @@ In addition to the required fields, the RFC-9457 standard defines several option
 Example:
 
 ```JSON
-"type": https://cmf.energysector.nl/reference-data/error-catalogue[/{categorie}]/{fout-type}",
+"type": "https://datatracker.ietf.org/doc/html/rfc9110#name-{code}-{code-summary}",
 "title": "Description of the error",
-"status": 401,
+"status": {code},
 "detail": "More details regarding the error can be found here",
 "instance": "urn:uuid:ebd2e7f0-1b27-11e8-accf-0ed5f89f718b"
 ```
@@ -49,10 +84,10 @@ When implementing a *Problem Details* record, it is important to remember that n
 
 ```json
 {
- "type": "https://cmf.energysector.nl/reference-data/error-catalogue/default/http-503",
- "title": "Service Unavailable",
- "status": 503,
- "detail": "Database cannot be reached"
+ "type": "https://datatracker.ietf.org/doc/html/rfc9110#name-401-unauthorized",
+ "title": "Unauthorized",
+ "status": 401,
+ "detail": "Invalid or missing credentials."
 }
 ```
 
@@ -67,67 +102,37 @@ When defining new problem types, the following rules must be observed:
 
 ------
 
-## Error types
+## Application specific error types
 
-We should aim to define a limited number of error types. Consider the following list, where the HTTP status code itself already provides a hint:  
-
-- Authentication / Authorisation Error  
-- Operation Precondition Error  
-- Communication Error  
-- Data Validation Error / Semantic Error  
-- Syntax Error  
-- Object(s) Not Found / Object(s) Deleted  
-- Parameter Validation Error / Missing Parameter(s) / Conflicting Parameters  
-- State Error (e.g., record locked, conflicting update, etc.)  
-- Too Many Results / Response Limit Reached  
-- Timeout / Server Busy / Server or Application Unreachable  
-- Software Error / Processing Error  
+Most of the HTTP errors can be identified using their standard URI (`https://datatracker.ietf.org/doc/html/rfc9110#name-{code}-{code-summary}`). In case of application errors, a specialized type is required with an URI that adheres to the URI standard for linked data. The accompanying HTTP error code will mostly be either 400 (in case of syntax errors) or 422 (in case of semantic errors).
 
 ### Error Type Catalogue  
 
 Ideally, we should maintain a catalogue of error types. This catalogue should contain the following information:  
 
-#### 1. Error Type  
-An URL that provides access to a specific entry in the catalogue. The format is:  
-`https://<provider-host>/reference-data/error-catalogue/<category>/<error-type>`  
+#### 1. Error type identifier  
+An URI that provides access to a specific entry in the catalogue. The format is:  
+`Https://referentiegegevens.energiesysteem.nl/error-codes/id/<error-code>`
 
-in more detail: 
+These URI's **should** be dereferencable so that, when copied into a browser, a page is returned containing detailed information regarding the error.
 
-| Field              | Definition                                                   |
-| ------------------ | ------------------------------------------------------------ |
-| *\<provider-host>* | Identifies the owner of the catalogue, which may be a virtual hostname. The URL does not necessarily have to point to an actual internet resource, although the standard encourages this. |
-| *reference-data*   | The error catalogue is part of a broader reference data catalogue. |
-| *error-catalogue*  | Specifies that this catalogue is for recording error types.  |
-| *\<category>*      | The error category, e.g., `"default"` for standard HTTP codes, `"validation"` for validation errors, `"software"` for software (processing) errors, etc. |
-| *\<error-type>*    | The specific name of the error type, e.g., `"parameter-validation"`. |
-
-Example:
+<u>Example</u>:
 
 ```json
-"https://cmf.energysector.nl/reference-data/error-catalogue/default/http-503"
+"https://referentiegegevens.energiesysteem.nl/error-codes/id/912"
 ```
 
 #### 2. Title
 
 A textual description of the error type, readable by end users, which can be used as the **title** attribute in error responses.
 
-#### 3. HTTP Status
+#### 3. HTTP status code
 
 The HTTP error status code (or codes) that this error type applies to. Ideally, there should be a one-to-one mapping, but some types may be relevant for multiple status codes.
 
-#### 4. Detail Template
+#### 4. Detail text
 
-A string containing placeholders for parameters, such as:
-
-```JSON
-"Conflicting parameters are: {param-list}"
-```
-
-This template, when expanded, provides the value for the **detail** field.
-
-#### 5. Extension Schema
-
-A JSON schema that describes any extension attributes. This must align with an extension object as described in **Enterprise Architect**.
+A string containins a description for the details text field.
 
 ------
 
@@ -191,51 +196,38 @@ The `categoryCode` and `code` attributes function as **implicit enumerations** (
 
 ## Example  
 
-Below is an example of a complete error response for a `400 Bad Request` error.  
+Below is an example of a complete error response for a `400 Bad Request` error.  We assume that error code 912 is defined in the catalog as a code for specifying *parameter validation errors* and error code 661 is associated with the check '*period start date must be earlier then period end date*.'
 
 The recommendation is to use `type`, `title`, and `detail` to provide as much generic, consistent, and reusable error information as possible (i.e., general error details), while using the `ApplicationProblem` extension record to return detailed information.  
 
-This approach allows for a relatively small set of error types to cover a wide variety of errors.  
+This approach allows for a relatively small set of error types to cover a wide variety of errors as shown in the example below:
 
 ```JSON
 {
-  "type": "https://cmf.energysector.nl/reference-data/error-catalogue/user-errors/parameter-validation",
-  "title": "One or more parameters did not validate correctly.",
+  "type": "https://referentiegegevens.energiesysteem.nl/error-codes/id/912",
+  "title": "Syntax errors in request",
   "status": 400,
-  "detail": "Conflicting parameters are: A, B, C, D",
+  "detail": "Parameter validation error.",
   "instance": "urn:uuid:4017fabc-1b28-11e8-accf-0ed5f89f718b",
   "traceID": "00-80e1afed08e019fc1110464cfa66635c-7a085853722dc6d2-01",
   "applicationProblem": [
-  {
-    "categoryCode": "PARAMETER_VALIDATION_ERROR",
-    "severityCode": "ERROR",
-    "message": [
     {
-      "identifier": "VAL01", 
-      "code": "CONFLICT", 
-      "text": "Parameters A and B cannot occur at the same time."
-    },
-    {
-      "identifier": "VAL12",
-      "code": "VALUE",
-      "text": "Value of parameter C must be greater than value of parameter D."
-    },
-    {
-      "identifier": "VAL12",
-      "code": "VALUE", 
-      "text": "Value of parameter B must be greater than 100"
-    }]
-  },
-  {
-    "categoryCode": "RESULT_SET_SIZE",
-    "severityCode": "WARNING",
-    "message": [
-    {
-      "identifier": "WRN03",
-      "code": "RESULT_SET",
-      "text": "Specified parameters may result in a very large result-set, not all results might be available."
-    }]
-  }]
+      "categoryCode": "PARAMETER_VALIDATION_ERROR",
+      "severityCode": "ERROR",
+      "message": [
+        {
+          "identifier": "https://referentiegegevens.energiesysteem.nl/error-codes/id/661", 
+          "code": "PERIOD_VALIDATION_ERROR", 
+          "text": "Query parameter 'startDate' must be earlier then query parameter 'endDate'."
+        },
+        {
+          "identifier": "https://referentiegegevens.energiesysteem.nl/error-codes/id/687", 
+          "code": "DOMAIN_VALIDATION_ERROR", 
+          "text": "Domain identifier is not owned by specified DSB'."
+        },
+      ]
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
Hoofdstuk toegevoegd over expliciete- en impliciete error codes en daar ook beschrijvingen aan gekoppeld.
Daarnaast door de tekst heen definities en beschrijvingen bijgewerkt en ook aangepast aan de meest recente URI richtlijnen voor linked data (deze zijn nu nog EDSN internal maar wil ik na mijn vakantie graag inbrengen in de werkgroep om er eventueel een sector standaard van te maken).